### PR TITLE
Fix: 회원가입시 인증코드 대신 비밀번호 재입력 추가 트랜잭션 queryRunner으로 변경 핸드폰 번호 

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,7 +5,6 @@ import { VerificationRequestDto } from './dto/verification-request.dto';
 import { SignUpDto } from './dto/sign-up.dto';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { LocalAuthGuard } from './guards/local-auth.guard';
-import { SignInDto } from './dto/sign-in.dto';
 
 @ApiTags('Auth')
 @Controller('auth')

--- a/src/auth/constants/auth.constants.ts
+++ b/src/auth/constants/auth.constants.ts
@@ -2,3 +2,4 @@ export const MIN_INTERESTS = 1;
 export const MAX_INTERESTS = 5;
 export const MIN_TECHS = 1;
 export const MAX_TECHS = 5;
+export const CODE_TTL = 300; // 300초

--- a/src/auth/dto/sign-up.dto.ts
+++ b/src/auth/dto/sign-up.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, IsEnum, IsNumber, IsArray, ArrayNotEmpty } from 'class-validator';
+import { IsString, IsNotEmpty, IsEnum, IsNumber, IsArray, ArrayNotEmpty, Validate, Matches } from 'class-validator';
 import { Gender } from '../../users/types/Gender.type';
 import { Region } from '../../users/types/region.type';
 import { Pet } from '../../users/types/pet.type';
@@ -6,19 +6,22 @@ import { BodyShape } from '../../users/types/bodyshape.type';
 import { Mbti } from '../../users/types/mbti.type';
 import { Religion } from '../../users/types/religion.type';
 import { Frequency } from '../../users/types/frequency.type';
+import { IsPasswordMatchingConstraint } from 'src/utils/decorators/password-match.decorator';
 
 export class SignUpDto {
   @IsNotEmpty()
   @IsString()
-  password: string;
-
-  @IsNotEmpty()
-  @IsString()
+  @Matches(/^010-\d{4}-\d{4}$/, { message: '전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)' })
   phoneNum: string;
 
   @IsNotEmpty()
   @IsString()
-  code: string;
+  password: string;
+
+  @IsString()
+  @IsNotEmpty({ message: '비밀번호 확인을 입력해주세요.' })
+  @Validate(IsPasswordMatchingConstraint)
+  readonly passwordConfirm: string;
 
   @IsNotEmpty()
   @IsString()

--- a/src/auth/sms/sms.service.ts
+++ b/src/auth/sms/sms.service.ts
@@ -6,6 +6,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Account } from '../entities/account.entity';
 import { CODE_BASE_NUMBER, CODE_MULTIPLY_NUMBER, VERIFICATION_CODE_EXPIRATION } from '../constants/sms.constants';
+import { formatPhoneNumber } from 'src/utils/phone.util';
 
 @Injectable()
 export class SmsService implements OnModuleInit {
@@ -39,7 +40,7 @@ export class SmsService implements OnModuleInit {
   }
 
   async sendSmsForVerification(phoneNum: string): Promise<any> {
-    const formattedPhoneNum = phoneNum.replace(/-/g, '');
+    const formattedPhoneNum = formatPhoneNumber(phoneNum);
 
     // 해당 전화번호를 가진 사용자가 없는 경우에만 SMS를 발송합니다.
     const foundAccount = await this.accountRepository.findOne({ where: { phoneNum: formattedPhoneNum } });

--- a/src/redis/redis.service.ts
+++ b/src/redis/redis.service.ts
@@ -22,6 +22,10 @@ export class RedisService {
     await this.redis.set(key, value);
   }
 
+  async setWithTTL(key: string, value: string, ttl: number): Promise<void> {
+    await this.redis.set(key, value, 'EX', ttl);
+  }
+
   async expireAt(key: string, timestamp: number): Promise<void> {
     await this.redis.expireat(key, timestamp);
   }

--- a/src/utils/decorators/password-match.decorator.ts
+++ b/src/utils/decorators/password-match.decorator.ts
@@ -1,0 +1,20 @@
+import { ValidatorConstraint, ValidatorConstraintInterface, ValidationArguments } from 'class-validator';
+
+@ValidatorConstraint({ name: 'isPasswordMatching', async: false })
+export class IsPasswordMatchingConstraint implements ValidatorConstraintInterface {
+  validate(passwordConfirm: string, args: ValidationArguments) {
+    const { password } = args.object as any;
+    if (!passwordConfirm) {
+      return false; // passwordConfirm 필드가 비어있는 경우 검증 실패
+    }
+    return passwordConfirm === password;
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    const { passwordConfirm } = args.object as any;
+    if (!passwordConfirm) {
+      return '비밀번호 확인을 입력해주세요.'; // passwordConfirm 필드가 비어있는 경우의 메시지
+    }
+    return '비밀번호 확인과 일치하지 않습니다.';
+  }
+}

--- a/src/utils/phone.util.ts
+++ b/src/utils/phone.util.ts
@@ -1,0 +1,6 @@
+export function formatPhoneNumber(phoneNum: string): string {
+  if (phoneNum.length === 11) {
+    return phoneNum.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3');
+  }
+  return phoneNum; // 이미 형식화된 경우 그대로 반환
+}


### PR DESCRIPTION
1. 회원가입시 코드 작성 부분 삭제
2. 회원가입시 비밀번호 재입력 추가
3. 회원가입시 코드 부재로 인한 전화번호 중복 에러처리
4.회원가입시 전화번호 (/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3')로 db에 저정하게 끔 변경.
5. 회원가입 시 트랜잭션 quertRunner로 변경