### PR TITLE
Fix: 거리계산 전 분기처리 추가 #69

### DIFF
--- a/src/matchings/matching.service.ts
+++ b/src/matchings/matching.service.ts
@@ -144,7 +144,7 @@ export class MatchingService {
         // 각 매칭 후보자의 위치 정보 가져오기 및 거리 계산
         for (const targetUser of targetUsers) {
           const targetLocation = await this.locationService.getLocationByUserId(targetUser.id);
-          if (targetLocation) {
+          if (targetLocation.latitude && targetLocation.longitude) {
             const distance = this.locationService.calculateDistance(
               userLocation.latitude,
               userLocation.longitude,


### PR DESCRIPTION
targetUser의 location (latitude, longitude)이 null 값이면 거리계산을 하지 않도록 수정