### PR TITLE
Rename, Add: 채팅메시지 entity 수정 #7, Chore: 매칭필터링 수정 #6,

### DIFF
--- a/seeds/factories/profile-image.factory.ts
+++ b/seeds/factories/profile-image.factory.ts
@@ -4,7 +4,7 @@ import { setSeederFactory } from 'typeorm-extension';
 
 export const profileImageFactory = setSeederFactory(ProfileImage, (faker: Faker) => {
   const profileImage = new ProfileImage();
-  profileImage.imageUrl = faker.image.avatar();
+  profileImage.imageUrl = faker.image.urlPicsumPhotos();
 
   return profileImage;
 });

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -116,13 +116,13 @@ export class AuthController {
   @Post('sign-out')
   @ApiBearerAuth()
   @UseGuards(RefreshTokenGuard)
-  async signOut(@UserInfo() user: User): Promise<ApiResponse<null>> {
+  async signOut(@UserInfo() user: User): Promise<ApiResponse<boolean>> {
     const userId = user.id;
     await this.authService.signOut(userId);
     return {
       statusCode: HttpStatus.OK,
       message: AUTH_MESSAGES.SIGN_OUT.SUCCEED,
-      data: null,
+      data: true,
     };
   }
 

--- a/src/chat-rooms/chat-room.controller.ts
+++ b/src/chat-rooms/chat-room.controller.ts
@@ -1,16 +1,18 @@
-import { Controller, Get, Param, Delete, UseGuards, Request, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Param, Delete, UseGuards, HttpStatus } from '@nestjs/common';
 import { ChatRoomService } from './chat-room.service';
 import { AccessTokenGuard } from 'src/auth/guards/access-token.guard';
 import { CHATROOM_MESSAGES } from './constants/chat-room.message.constant';
 import { ApiResponse } from 'src/common/interceptors/response/response.interface';
+import { UserInfo } from 'src/utils/decorators/user-info.decorator';
+import { User } from 'src/users/entities/user.entity';
 
 @UseGuards(AccessTokenGuard)
 @Controller('chat-rooms')
 export class ChatRoomController {
   constructor(private readonly chatRoomService: ChatRoomService) {}
   @Get()
-  async getUserChatRooms(@Request() req) {
-    const userId = req.user.id;
+  async getUserChatRooms(@UserInfo() user: User) {
+    const userId = user.id;
     const chatRooms = await this.chatRoomService.getUserChatRooms(userId);
     return {
       statusCode: HttpStatus.OK,
@@ -20,8 +22,8 @@ export class ChatRoomController {
   }
 
   @Delete(':roomId')
-  async exitChatRoom(@Param('roomId') roomId: number, @Request() req): Promise<ApiResponse<null>> {
-    const userId = req.user.id;
+  async exitChatRoom(@Param('roomId') roomId: number, @UserInfo() user: User): Promise<ApiResponse<null>> {
+    const userId = user.id;
     await this.chatRoomService.exitChatRoom(userId, roomId);
     return {
       statusCode: HttpStatus.OK,

--- a/src/chat-rooms/chat-room.service.spec.ts
+++ b/src/chat-rooms/chat-room.service.spec.ts
@@ -1,15 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ChatRoomsService } from './chat-room.service';
+import { ChatRoomService } from './chat-room.service';
 
 describe('ChatRoomsService', () => {
-  let service: ChatRoomsService;
+  let service: ChatRoomService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ChatRoomsService],
+      providers: [ChatRoomService],
     }).compile();
 
-    service = module.get<ChatRoomsService>(ChatRoomsService);
+    service = module.get<ChatRoomService>(ChatRoomService);
   });
 
   it('should be defined', () => {

--- a/src/chat-rooms/entities/chat-message.entity.ts
+++ b/src/chat-rooms/entities/chat-message.entity.ts
@@ -1,7 +1,8 @@
 import { Column, CreateDateColumn, Entity, JoinColumn, ManyToMany, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { ChatRoom } from './chat-room.entity';
 import { User } from '../../users/entities/user.entity';
-import { IsBoolean, IsInt, IsNotEmpty, IsString } from 'class-validator';
+import { IsBoolean, IsEnum, IsInt, IsNotEmpty, IsString } from 'class-validator';
+import { MessageType } from '../types/message.type';
 
 @Entity({ name: 'chat_messages' })
 export class ChatMessage {
@@ -21,7 +22,11 @@ export class ChatMessage {
   @IsNotEmpty()
   @IsString()
   @Column({ type: 'text' })
-  text: string;
+  content: string;
+
+  @IsEnum(MessageType)
+  @Column({ type: 'enum', enum: MessageType, default: MessageType.TEXT })
+  type: MessageType;
 
   @IsBoolean()
   @Column({ type: 'boolean', default: false })

--- a/src/chat-rooms/types/message.type.ts
+++ b/src/chat-rooms/types/message.type.ts
@@ -1,0 +1,4 @@
+export enum MessageType {
+  TEXT = 'TEXT',
+  IMAGE = 'IMAGE',
+}

--- a/src/locations/location.module.ts
+++ b/src/locations/location.module.ts
@@ -4,9 +4,10 @@ import { Location } from './entities/location.entity';
 import { LocationService } from './location.service';
 import { LocationController } from './location.controller';
 import { User } from 'src/users/entities/user.entity';
+import { UserModule } from 'src/users/user.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Location, User])],
+  imports: [TypeOrmModule.forFeature([Location, User]), UserModule],
   controllers: [LocationController],
   providers: [LocationService],
   exports: [LocationService],

--- a/src/locations/location.service.ts
+++ b/src/locations/location.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Location } from './entities/location.entity';
 import { User } from '../users/entities/user.entity';
+import { UserService } from 'src/users/user.service';
 
 @Injectable()
 export class LocationService {
@@ -11,42 +12,47 @@ export class LocationService {
     private readonly locationRepository: Repository<Location>,
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+
+    private readonly userService: UserService,
   ) {}
 
   private toRadians(degrees: number): number {
     return degrees * (Math.PI / 180);
   }
 
-  public calculateDistance(lat1: number, lon1: number, lat2: number, lon2: number): number {
-    const R = 6371; // 지구의 반지름 (단위: km)
-    const dLat = this.toRadians(lat2 - lat1);
-    const dLon = this.toRadians(lon1 - lon2);
-    const a =
-      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-      Math.cos(this.toRadians(lat1)) * Math.cos(this.toRadians(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
-    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-    return R * c; // 두 지점 간의 거리 (단위: km)
+  public calculateDistance(lat1: number, lon1: number, lat2: number, lon2: number): number | null {
+    if (lat1 && lon1 && lat2 && lon2) {
+      const R = 6371; // 지구의 반지름 (단위: km)
+      const dLat = this.toRadians(lat2 - lat1);
+      const dLon = this.toRadians(lon1 - lon2);
+      const a =
+        Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+        Math.cos(this.toRadians(lat1)) * Math.cos(this.toRadians(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+      const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+      return R * c; // 두 지점 간의 거리 (단위: km)
+    } else {
+      return null;
+    }
   }
 
-  async addLocation(userId: number, latitude: number, longitude: number): Promise<Location> {
-    const user = await this.userRepository.findOne({ where: { id: userId } });
-    if (!user) {
-      throw new Error('User not found');
-    }
+  async addLocation(userId: number, latitude: number, longitude: number): Promise<boolean> {
+    await this.userService.validateUserExists(userId);
 
     // 기존 위치 정보가 있는지 확인
-    let location = await this.locationRepository.findOne({ where: { userId } });
+    let location = await this.getLocationByUserId(userId);
 
     if (location) {
       // 기존 위치 정보 업데이트
       location.latitude = latitude;
       location.longitude = longitude;
+      await this.locationRepository.update({ userId }, { latitude, longitude });
     } else {
-      // 새로운 위치 정보 생성
-      location = this.locationRepository.create({ user, latitude, longitude });
+      // 새로운 위치 정보 생성 및 저장
+      location = this.locationRepository.create({ userId, latitude, longitude });
+      await this.locationRepository.save(location);
     }
 
-    return await this.locationRepository.save(location);
+    return true;
   }
 
   async getLocationByUserId(userId: number): Promise<Location> {
@@ -55,11 +61,11 @@ export class LocationService {
 
   // 거리 계산 테스트를 위한 메서드 추가
   async testCalculateDistance(userId1: number, userId2: number): Promise<number> {
-    const location1 = await this.locationRepository.findOne({ where: { user: { id: userId1 } } });
-    const location2 = await this.locationRepository.findOne({ where: { user: { id: userId2 } } });
+    const location1 = await this.locationRepository.findOne({ where: { userId: userId1 } });
+    const location2 = await this.locationRepository.findOne({ where: { userId: userId2 } });
 
     if (!location1 || !location2) {
-      throw new Error('One or both users not found');
+      throw new Error('두 유저 모두의 위치정보가 필요합니다.');
     }
 
     const distance = this.calculateDistance(

--- a/src/matchings/matching.service.ts
+++ b/src/matchings/matching.service.ts
@@ -63,10 +63,6 @@ export class MatchingService {
       let maxBirthYear: number;
 
       switch (preferences.ageGap) {
-        case PreferredAgeGap.WITHIN_3_YEARS:
-          minBirthYear = birthYear - 3;
-          maxBirthYear = birthYear + 3;
-          break;
         case PreferredAgeGap.WITHIN_5_YEARS:
           minBirthYear = birthYear - 5;
           maxBirthYear = birthYear + 5;
@@ -170,23 +166,23 @@ export class MatchingService {
       // 성별 필터링
       this.applyGenderFilter(queryBuilder, preferences, user.gender);
 
-      // 나이차이 필터링
-      this.applyAgeGapFilter(queryBuilder, preferences, user.birthDate);
-
-      // 키 필터링
-      this.applyHeightFilter(queryBuilder, preferences.height);
-
-      // 체형 필터링
-      this.applyBodyShapeFilter(queryBuilder, preferences.bodyShape);
-
-      // 흡연빈도 필터링
-      this.applySmokingFrequencyFilter(queryBuilder, preferences.smokingFreq);
-
-      // 움주빈도 필터링
-      this.applyDrinkingFrequencyFilter(queryBuilder, preferences.drinkingFreq);
-
       // 거리 필터링
       this.applyDistanceFilter(queryBuilder, preferences.distance, user.location);
+
+      // 나이차이 필터링
+      // this.applyAgeGapFilter(queryBuilder, preferences, user.birthDate);
+
+      // // 키 필터링
+      // this.applyHeightFilter(queryBuilder, preferences.height);
+
+      // // 체형 필터링
+      // this.applyBodyShapeFilter(queryBuilder, preferences.bodyShape);
+
+      // // 흡연빈도 필터링
+      // this.applySmokingFrequencyFilter(queryBuilder, preferences.smokingFreq);
+
+      // // 움주빈도 필터링
+      // this.applyDrinkingFrequencyFilter(queryBuilder, preferences.drinkingFreq);
     }
 
     // 기존 매칭이 되어 좋아요/싫어요 한 사용자는 제외

--- a/src/preferences/dto/update-preference.dto.ts
+++ b/src/preferences/dto/update-preference.dto.ts
@@ -13,7 +13,7 @@ export class UpdatePreferenceDto {
 
   @IsOptional()
   @IsEnum(PreferredAgeGap, {
-    message: 'ageGap은 [3살 이내], [5살 이내], [10살 이내], [상관 없음] 중에 선택해주세요',
+    message: 'ageGap은 [5살 이내], [10살 이내], [상관 없음] 중에 선택해주세요',
   })
   ageGap?: PreferredAgeGap;
 

--- a/src/preferences/preference.service.ts
+++ b/src/preferences/preference.service.ts
@@ -15,11 +15,11 @@ export class PreferenceService {
   ) {}
 
   async get(userId: number): Promise<Preferences> {
-    return await this.preferenceRepository.findOne({ where: { user: { id: userId } } });
+    return await this.preferenceRepository.findOne({ where: { userId } });
   }
 
   async update(userId: number, updatePreferenceDto: UpdatePreferenceDto): Promise<void> {
-    const preferences = await this.preferenceRepository.findOne({ where: { user: { id: userId } } });
+    const preferences = await this.preferenceRepository.findOne({ where: { userId } });
     if (!preferences) {
       throw new NotFoundException(`사용자 ID ${userId}의 매칭 선호도를 찾을 수 없습니다.`);
     }

--- a/src/preferences/types/preferred-age-gap.type.ts
+++ b/src/preferences/types/preferred-age-gap.type.ts
@@ -1,5 +1,4 @@
 export enum PreferredAgeGap {
-  WITHIN_3_YEARS = '3살 이내',
   WITHIN_5_YEARS = '5살 이내',
   WITHIN_10_YEARS = '10살 이내',
   NO_PREFERENCE = '상관 없음',

--- a/src/preferences/types/preferred-print-width.type.ts
+++ b/src/preferences/types/preferred-print-width.type.ts
@@ -1,0 +1,5 @@
+export enum PreferredPrintWidth {
+  PW80 = 80,
+  PW120 = 120,
+  NO_PREFERENCE = '상관 없음',
+}

--- a/src/users/types/gender.type.ts
+++ b/src/users/types/gender.type.ts
@@ -1,4 +1,4 @@
 export enum Gender {
-  MALE = 'MALE',
-  FEMALE = 'FEMALE',
+  MALE = '남',
+  FEMALE = '여',
 }

--- a/src/users/types/pet.type.ts
+++ b/src/users/types/pet.type.ts
@@ -1,7 +1,7 @@
 export enum Pet {
-  DOG = 'DOG',
-  CAT = 'CAT',
-  ETC = 'ETC',
-  NONE = 'NONE',
-  VSCODE_PET = 'VSCODE_PET',
+  DOG = '반려견',
+  CAT = '반려묘',
+  ETC = '기타 반려동물',
+  NONE = '없음',
+  VSCODE_PET = 'VSCODE PET',
 }

--- a/static/index1.html
+++ b/static/index1.html
@@ -77,7 +77,7 @@
         if (!joinCheck) {
           data.messages.forEach((msg) => {
             const item = document.createElement('li');
-            item.textContent = `${msg.nickname}:${msg.text}`;
+            item.textContent = `${msg.nickname}:${msg.content}`;
             messagesList.appendChild(item);
           });
         }
@@ -91,7 +91,7 @@
 
       chatSocket.on('message', (message) => {
         const item = document.createElement('li');
-        item.textContent = `${message.nickname}: ${message.text}`;
+        item.textContent = `${message.nickname}: ${message.content}`;
         messagesList.appendChild(item);
       });
 

--- a/static/index2.html
+++ b/static/index2.html
@@ -74,7 +74,7 @@
         if (!joinCheck) {
           data.messages.forEach((msg) => {
             const item = document.createElement('li');
-            item.textContent = `${msg.nickname}:${msg.text}`;
+            item.textContent = `${msg.nickname}:${msg.content}`;
             messagesList.appendChild(item);
           });
         }
@@ -88,7 +88,7 @@
 
       chatSocket.on('message', (message) => {
         const item = document.createElement('li');
-        item.textContent = `${message.nickname}: ${message.text}`;
+        item.textContent = `${message.nickname}: ${message.content}`;
         messagesList.appendChild(item);
       });
 


### PR DESCRIPTION
Rename: 채팅메시지 entity의 text를 content로 수정 #7
Add: 채팅메시지 entity에 enum 값의 type 필드 추가 #7
Chore: 매칭필터링 조건 일부 미적용으로 처리 #6, related to: #68
Chore: 매칭필터링 설정에서 나이차이 '3살 이내' 삭제 #68, related to: #6
Rename: 성별 enum에서 MALE, FEMALE을 남, 여로 수정, related to: #5
Fix: location service의 거리계산함수에서 입력값에 null이 있으면 null을 반환하도록 수정 #69, related to: #6